### PR TITLE
Fix landblock portal sending (would create a landblock of instance id 0).

### DIFF
--- a/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/DeveloperCommands.cs
@@ -98,7 +98,7 @@ namespace ACE.Server.Command.Handlers
         public static void HandleNudge(Session session, params string[] parameters)
         {
             var pos = session.Player.GetPosition(PositionType.Location);
-            if (WorldObject.AdjustDungeonCells(pos))
+            if (WorldObject.AdjustDungeonCells(pos, pos.Instance))
             {
                 pos.PositionZ += 0.005000f;
                 var posReadable = PostionAsLandblocksGoogleSpreadsheetFormat(pos);

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -197,6 +197,9 @@ namespace ACE.Server.Entity
 
         public void Init(EphemeralRealm ephemeralRealm, bool reload = false)
         {
+            if (Instance == 0)
+                log.Error("Error: Loading Landblock with Instance ID = 0");
+
             RealmRuleset = GetOrApplyRuleset(ephemeralRealm);
             InnerRealmInfo = ephemeralRealm;
 

--- a/Source/ACE.Server/WorldObjects/Player_Move2.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move2.cs
@@ -5,6 +5,7 @@ using ACE.Server.Entity;
 using ACE.Server.Physics;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Common;
+using System.Linq;
 
 namespace ACE.Server.WorldObjects
 {

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -740,23 +740,27 @@ namespace ACE.Server.WorldObjects
         }
 
         // todo: This should really be an extension method for Position, or a static method within Position or even AdjustPos
-        public static void AdjustDungeon(Position pos)
+        public static void AdjustDungeon(Position pos, uint? instance = null)
         {
-            AdjustDungeonPos(pos);
-            AdjustDungeonCells(pos);
+            var iid = instance.GetValueOrDefault(pos.Instance);
+            if (iid == 0)
+                log.Error("AdjustDungeon: Instance ID is 0! Instance ID needs to be passed to this method if the position lacks an instance id.");
+            
+            AdjustDungeonPos(pos, iid);
+            AdjustDungeonCells(pos, iid);
         }
 
         // todo: This should really be an extension method for Position, or a static method within Position or even AdjustPos
-        public static bool AdjustDungeonCells(Position pos)
+        public static bool AdjustDungeonCells(Position pos, uint iid)
         {
             if (pos == null) return false;
 
-            var landblock = LScape.get_landblock(pos.Cell, pos.Instance);
+            var landblock = LScape.get_landblock(pos.Cell, iid);
             if (landblock == null || !landblock.HasDungeon) return false;
 
             var dungeonID = pos.Cell >> 16;
 
-            var adjustCell = AdjustCell.Get(dungeonID, pos.Instance);
+            var adjustCell = AdjustCell.Get(dungeonID, iid);
             var cellID = adjustCell.GetCell(pos.Pos);
 
             if (cellID != null && pos.Cell != cellID.Value)
@@ -768,11 +772,11 @@ namespace ACE.Server.WorldObjects
         }
 
         // todo: This should really be an extension method for Position, or a static method within Position, or even AdjustPos
-        public static bool AdjustDungeonPos(Position pos)
+        public static bool AdjustDungeonPos(Position pos, uint iid)
         {
             if (pos == null) return false;
 
-            var landblock = LScape.get_landblock(pos.Cell, pos.Instance);
+            var landblock = LScape.get_landblock(pos.Cell, iid);
             if (landblock == null || !landblock.HasDungeon) return false;
 
             var dungeonID = pos.Cell >> 16;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1162,7 +1162,7 @@ namespace ACE.Server.WorldObjects
                     portalRecall.AddAction(targetPlayer, () =>
                     {
                         var teleportDest = new Position(portal.Destination);
-                        AdjustDungeon(teleportDest);
+                        AdjustDungeon(teleportDest, targetPlayer.Location.Instance);
 
                         targetPlayer.Teleport(teleportDest);
                     });
@@ -1366,7 +1366,7 @@ namespace ACE.Server.WorldObjects
                 portalSendingChain.AddAction(targetPlayer, () =>
                 {
                     var teleportDest = new Position(spell.Position);
-                    AdjustDungeon(teleportDest);
+                    AdjustDungeon(teleportDest, targetPlayer.Location.Instance);
 
                     targetPlayer.Teleport(teleportDest);
 
@@ -1379,7 +1379,7 @@ namespace ACE.Server.WorldObjects
                 // monsters can cast some portal spells on themselves too, possibly?
                 // under certain circumstances, such as ensuring the destination is the same landblock
                 var teleportDest = new Position(spell.Position);
-                AdjustDungeon(teleportDest);
+                AdjustDungeon(teleportDest, targetCreature.Location.Instance);
 
                 targetCreature.FakeTeleport(teleportDest);
             }
@@ -1419,7 +1419,7 @@ namespace ACE.Server.WorldObjects
             portalSendingChain.AddAction(targetPlayer, () =>
             {
                 var teleportDest = new Position(spell.Position);
-                AdjustDungeon(teleportDest);
+                AdjustDungeon(teleportDest, targetPlayer.Location.Instance);
 
                 targetPlayer.Teleport(teleportDest);
 


### PR DESCRIPTION
Also, casting portal recall will use current instance id by default 
Add logging for landblocks of instance id 0 being created